### PR TITLE
Smaller docker images for server updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,36 @@
-FROM node:12
+FROM node:12-alpine AS build
+RUN mkdir -p /app/backend && mkdir -p /app/frontend
 
-RUN mkdir -p /app
-COPY . /app
+# Install dependencies (changes not too often)
+COPY backend/package.json /app/backend/package.json
+COPY backend/package-lock.json /app/backend/package-lock.json
+COPY frontend/package.json /app/frontend/package.json
+COPY frontend/yarn.lock /app/frontend/yarn.lock
 
 WORKDIR /app/frontend
-RUN yarn install && yarn build
+RUN yarn install
 
 WORKDIR /app/backend
-RUN npm install
+RUN npm ci
 
+# Copy regular files and build
+COPY backend /app/backend
+COPY frontend /app/frontend
+
+WORKDIR /app/backend
+
+WORKDIR /app/frontend
+RUN yarn build
+
+FROM node:12-alpine AS runner
+RUN mkdir -p /app/backend && mkdir -p /app/frontend
+COPY backend/package.json /app/backend/package.json
+COPY backend/package-lock.json /app/backend/package-lock.json
+COPY frontend/package.json /app/frontend/package.json
+COPY frontend/yarn.lock /app/frontend/yarn.lock
+WORKDIR /app/backend
+RUN npm ci --only=production
+COPY --from=builder /app/frontend/build /app/frontend/build
+
+# Run the backend
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,9 @@ RUN yarn build
 FROM node:12-alpine AS runner
 RUN mkdir -p /app/backend && mkdir -p /app/frontend
 WORKDIR /app/backend
-COPY backend/package.json /app/backend/package.json
-COPY backend/package-lock.json /app/backend/package-lock.json
-RUN npm ci --only=production
-COPY backend /app/backend
+COPY --from=build /app/backend /app/backend
 COPY --from=build /app/frontend/build /app/frontend/build
+RUN npm ci --only=production
 
 # Run the backend
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,12 @@ RUN yarn build
 
 FROM node:12-alpine AS runner
 RUN mkdir -p /app/backend && mkdir -p /app/frontend
+WORKDIR /app/backend
 COPY backend/package.json /app/backend/package.json
 COPY backend/package-lock.json /app/backend/package-lock.json
-COPY frontend/package.json /app/frontend/package.json
-COPY frontend/yarn.lock /app/frontend/yarn.lock
-WORKDIR /app/backend
 RUN npm ci --only=production
-COPY --from=builder /app/frontend/build /app/frontend/build
+COPY backend /app/backend
+COPY --from=build /app/frontend/build /app/frontend/build
 
 # Run the backend
 CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,13 +26,12 @@ services:
       - "traefik.http.routers.platzhalterio.rule=Host(`beta.platzhalter.io`)"
       - "traefik.http.routers.platzhalterio.entrypoints=websecure"
       - "traefik.http.routers.platzhalterio.tls.certresolver=leresolver"
+      - "traefik.http.services.platzhalterio.loadbalancer.server.port=80"
     links:
       - "postgres:postgres"
     networks:
       - web
       - platzhalterio
-    ports:
-      - "0.0.0.0:8080:80"
 
   postgres:
     container_name: postgres
@@ -44,7 +43,5 @@ services:
       - traefik.enable=false
     networks:
       - platzhalterio
-    ports:
-      - "0.0.0.0:5432:5432"
     volumes:
       - platzhalterio-data:/var/lib/postgresql/data


### PR DESCRIPTION
**Checklist**

- [x] Resolves #70 
- [x] The [code of conduct](../blob/master/.github/CODE_OF_CONDUCT.md) is respected
- [x] Added project
- [x] Added label "Review needed"
- [x] Assigned a reviewer

**Reviewer**

- [ ] I've checked out the code and tested it myself.

**Changes**

- Create a multi-stage build to only copy regular dependencies and the final builds
- Use `node:12-alpine` docker base image for building and serving
- Some smaller optimizations to the Docker image for quicker builds (do dependency installation before regular build for example)