### PR TITLE
71 slots every 15 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ Platzhalter.io is a project started at ITC1's digital hackathon.
 
 # Building / setup 🛠 #
 
+To start the backend server, run:
+
+```
+docker-compose up
+```
+
+If you need to rebuild the code, run `docker-compose build`. To make 
+development faster, use frontend and backend as docker volumes and add them to
+the docker command or use your own `docker-compose.yml` file.
+
+## Deployment ##
 To initialize the server, run `server-install.sh`. It will setup the (Ubuntu)
 server by creating a user to work with and install docker if its not installed
 yet.

--- a/frontend/.storybook/helper/connected.tsx
+++ b/frontend/.storybook/helper/connected.tsx
@@ -1,0 +1,23 @@
+import React, { Suspense } from "react";
+import { connection as mockedConnection } from "./fetcher/connection";
+import { FetcherProvider } from "../../src/service/server/connection";
+
+interface ConnectedProps {
+  children: React.ReactNode;
+  connection?: typeof mockedConnection;
+  shopId?: string;
+}
+
+const Connected: React.FC<ConnectedProps> = ({
+  children,
+  connection = mockedConnection,
+  shopId = "cozy-costumes",
+}) => {
+  return (
+    <FetcherProvider currentShopId={shopId} connection={connection}>
+      <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
+    </FetcherProvider>
+  );
+};
+
+export default Connected;

--- a/frontend/.storybook/helper/fetcher/fetcher.ts
+++ b/frontend/.storybook/helper/fetcher/fetcher.ts
@@ -22,10 +22,53 @@ export const fetcher: fetcherFn<any> = async (url: string) => {
     return shop;
   }
   if (/\/shop\/([^/]+?)\/timeslot\/?$/.test(url)) {
-    return [];
+    return {
+      member: [
+        {
+          day: 1,
+          start: "16:30:00",
+          end: "23:30:00",
+          customers: 3,
+          minDuration: 15,
+          maxDuration: 60,
+        },
+        {
+          day: 2,
+          start: "16:30:00",
+          end: "23:30:00",
+          customers: 3,
+          minDuration: 15,
+          maxDuration: 60,
+        },
+        {
+          day: 3,
+          start: "16:30:00",
+          end: "23:30:00",
+          customers: 3,
+          minDuration: 15,
+          maxDuration: 60,
+        },
+        {
+          day: 4,
+          start: "16:30:00",
+          end: "23:30:00",
+          customers: 3,
+          minDuration: 15,
+          maxDuration: 60,
+        },
+        {
+          day: 5,
+          start: "16:30:00",
+          end: "23:30:00",
+          customers: 3,
+          minDuration: 15,
+          maxDuration: 60,
+        },
+      ],
+    };
   }
   if (/\/shop\/([^/]+?)\/ticket\/?$/.test(url)) {
-    return [];
+    return { member: [] };
   }
   return [];
 };

--- a/frontend/src/component/available-tickets/available-tickets.tsx
+++ b/frontend/src/component/available-tickets/available-tickets.tsx
@@ -38,10 +38,13 @@ const AvailableTickets: React.FC<AvailableTicketsProps> = ({
     start.toISOString()
   )}&end=${encodeURIComponent(end.toISOString())}`;
   const data = useShopFetch<Ticket[]>(url, { mapper });
+  const from = new Date(
+    Math.floor(Date.now() / (15 * 60 * 1000)) * 15 * 60 * 1000
+  );
   const slots = generateSlotsFromData({
     slots: data,
     duration,
-    from: new Date(),
+    from,
   });
   const hasSlots = slots.length > 0;
   const noSlots = !hasSlots;

--- a/frontend/src/component/available-tickets/available-tickets.tsx
+++ b/frontend/src/component/available-tickets/available-tickets.tsx
@@ -41,14 +41,14 @@ const AvailableTickets: React.FC<AvailableTicketsProps> = ({
   const from = new Date(
     Math.floor(Date.now() / (15 * 60 * 1000)) * 15 * 60 * 1000
   );
-  const slots = generateSlotsFromData({
+  const generatedSlots = generateSlotsFromData({
     slots: data,
     duration,
     from,
   });
-  const hasSlots = slots.length > 0;
+  const hasSlots = generatedSlots.length > 0;
   const noSlots = !hasSlots;
-  const dailySlots = slotsPerDays(slots);
+  const dailySlots = slotsPerDays(generatedSlots);
   return (
     <div className={styles.root}>
       {hasSlots && (

--- a/frontend/src/component/choose-duration/choose-duration.story.tsx
+++ b/frontend/src/component/choose-duration/choose-duration.story.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Connected from "../../../.storybook/helper/connected";
 import ChooseDuration from "./choose-duration";
 import { action } from "@storybook/addon-actions";
 
@@ -7,6 +8,8 @@ export default {
   component: ChooseDuration,
 };
 
-export const Default10 = () => (
-  <ChooseDuration defaultValue={10} onChange={action("choose slot")} />
+export const Default = () => (
+  <Connected>
+    <ChooseDuration onChange={action("choose slot")} />
+  </Connected>
 );

--- a/frontend/src/component/choose-duration/choose-duration.tsx
+++ b/frontend/src/component/choose-duration/choose-duration.tsx
@@ -6,7 +6,6 @@ import styles from "./choose-duration.module.css";
 import { useShop } from "../../service/server/connection";
 
 interface ChooseDurationProps {
-  defaultValue?: number;
   onChange: (duration: number) => void;
 }
 

--- a/frontend/src/component/choose-duration/choose-duration.tsx
+++ b/frontend/src/component/choose-duration/choose-duration.tsx
@@ -23,7 +23,7 @@ const ChooseDuration: React.FC<ChooseDurationProps> = ({ onChange }) => {
       : 0;
   const maxDuration =
     timeslots.length > 0
-      ? timeslots.sort((a, b) => a.maxDuration - b.maxDuration)[0].maxDuration
+      ? timeslots.sort((a, b) => b.maxDuration - a.maxDuration)[0].maxDuration
       : 0;
 
   return (

--- a/frontend/src/component/choose-duration/choose-duration.tsx
+++ b/frontend/src/component/choose-duration/choose-duration.tsx
@@ -3,22 +3,36 @@ import React from "react";
 import Slider from "../slider/slider";
 
 import styles from "./choose-duration.module.css";
-import { useShop } from "../../service/server/connection";
+import { useShopFetch } from "../../service/server/connection";
+import { Timeslot } from "../../service/domain";
 
 interface ChooseDurationProps {
   onChange: (duration: number) => void;
 }
 
+function mapper(data: any): Timeslot[] {
+  return data.member as Timeslot[];
+}
+
 const ChooseDuration: React.FC<ChooseDurationProps> = ({ onChange }) => {
-  const shop = useShop();
+  const url = `/timeslot`;
+  const timeslots = useShopFetch<Timeslot[]>(url, { mapper });
+  const minDuration =
+    timeslots.length > 0
+      ? timeslots.sort((a, b) => a.minDuration - b.minDuration)[0].minDuration
+      : 0;
+  const maxDuration =
+    timeslots.length > 0
+      ? timeslots.sort((a, b) => a.maxDuration - b.maxDuration)[0].maxDuration
+      : 0;
 
   return (
     <div className={styles.root}>
       <div className={styles.duration}>
         <h2>Wie viel Zeit benötigst Du?</h2>
         <Slider
-          max={shop.maxDuration}
-          min={shop.minDuration || 0}
+          max={maxDuration}
+          min={minDuration || 0}
           onChange={(value) => {
             if (value) {
               onChange(value as number);

--- a/frontend/src/component/choose-ticket/choose-ticket.tsx
+++ b/frontend/src/component/choose-ticket/choose-ticket.tsx
@@ -22,13 +22,13 @@ const ChooseTicket: React.FC<ChooseTicketProps> = ({ onSelect }) => {
     const now = Math.floor(Date.now() / (5 * 60 * 1000)) * (5 * 60 * 1000);
     return new Date(now);
   }, []);
-  const end = useMemo(() => new Date(+start + 2 * 24 * 60 * 60 * 1000), [
+  const end = useMemo(() => new Date(+start + 4 * 24 * 60 * 60 * 1000), [
     start,
   ]);
 
   return (
     <div className={styles.root}>
-      <ChooseDuration defaultValue={duration} onChange={setDuration} />
+      <ChooseDuration onChange={setDuration} />
       <Spacer />
       <Suspense fallback={<Loader />}>
         <AvailableTickets


### PR DESCRIPTION
**Checklist**

- [x] Resolves #71
- [x] The [code of conduct](../blob/master/.github/CODE_OF_CONDUCT.md) is respected
- [x] Added project
- [x] Added label "Review needed"
- [x] Assigned a reviewer

**Reviewer**

- [ ] I've checked out the code and tested it myself.

**Changes**

- Finds the next three days (plus today) for available timeslots
- Added a helper HOC for Storybook to make `useShop` etc. work again
- Duration for customer is now based on the min and max durations of the timeslots.

There is a conceptual issue for timeslots and availabilities currently: Available timeslots can overlap and if the user sets their duration to the maximum available duration, the slots with less maximum duration could be selected with a longer duration (as much as fits). I will create a new issue to discuss this.