### PR TITLE
Add start and end times as query parameters

### DIFF
--- a/frontend/src/component/choose-ticket/choose-ticket.tsx
+++ b/frontend/src/component/choose-ticket/choose-ticket.tsx
@@ -8,6 +8,7 @@ import styles from "./choose-ticket.module.css";
 import Button from "../button/button";
 import { useShop } from "../../service/server/connection";
 import Loader from "../loader/loader";
+import { useLocation } from "react-router-dom";
 
 interface ChooseTicketProps {
   onSelect: (ticket: AvailableSlot) => void;
@@ -17,15 +18,21 @@ const ChooseTicket: React.FC<ChooseTicketProps> = ({ onSelect }) => {
   const shop = useShop();
   const [duration, setDuration] = useState<number>(15);
   const [selectedTicket, setSelectedTicket] = useState<AvailableSlot>();
-  // use start / end from url
+  const queryString = useLocation().search;
   const start = useMemo(() => {
-    // The latest 5 minutes
-    const now = Math.floor(Date.now() / (5 * 60 * 1000)) * (5 * 60 * 1000);
-    return new Date(now);
-  }, []);
-  const end = useMemo(() => new Date(+start + 4 * 24 * 60 * 60 * 1000), [
-    start,
-  ]);
+    return new Date(
+      new URLSearchParams(queryString).get("start") ||
+        Math.floor(Date.now() / (5 * 60 * 1000)) * (5 * 60 * 1000)
+    );
+  }, [queryString]);
+  const end = useMemo(
+    () =>
+      new Date(
+        new URLSearchParams(queryString).get("end") ||
+          +start + 4 * 24 * 60 * 60 * 1000
+      ),
+    [queryString, start]
+  );
 
   return (
     <div className={styles.root}>

--- a/frontend/src/component/choose-ticket/choose-ticket.tsx
+++ b/frontend/src/component/choose-ticket/choose-ticket.tsx
@@ -17,6 +17,7 @@ const ChooseTicket: React.FC<ChooseTicketProps> = ({ onSelect }) => {
   const shop = useShop();
   const [duration, setDuration] = useState<number>(15);
   const [selectedTicket, setSelectedTicket] = useState<AvailableSlot>();
+  // use start / end from url
   const start = useMemo(() => {
     // The latest 5 minutes
     const now = Math.floor(Date.now() / (5 * 60 * 1000)) * (5 * 60 * 1000);

--- a/frontend/src/component/choose-ticket/choose-ticket.tsx
+++ b/frontend/src/component/choose-ticket/choose-ticket.tsx
@@ -28,8 +28,18 @@ const ChooseTicket: React.FC<ChooseTicketProps> = ({ onSelect }) => {
   const end = useMemo(
     () =>
       new Date(
-        new URLSearchParams(queryString).get("end") ||
-          +start + 4 * 24 * 60 * 60 * 1000
+        // end shouldn't be greater than 14 days from start
+        Math.min(
+          // end needs to be >= start time
+          Math.max(
+            +new Date(new URLSearchParams(queryString).get("end") || +start),
+            +new Date(
+              new URLSearchParams(queryString).get("end") ||
+                +start + 4 * 24 * 60 * 60 * 1000
+            )
+          ),
+          +start + 14 * 24 * 60 * 60 * 1000
+        )
       ),
     [queryString, start]
   );


### PR DESCRIPTION
**Checklist**

- [x] Resolves #87
- [x] The [code of conduct](../blob/master/.github/CODE_OF_CONDUCT.md) is respected
- [x] Added project
- [x] Added label "Review needed"
- [x] Assigned a reviewer

**Reviewer**

- [ ] I've checked out the code and tested it myself.

**Changes**

- Added check for start and end query parameters in a shop, making links like this possible: https://beta.platzhalter.io/shop/goldener-bizeps/?start=2020-08-04T14:00:00Z&end=2020-07-30T18:00:00Z
